### PR TITLE
Handle the JWT auth token

### DIFF
--- a/src/app/api/graphql/route.tsx
+++ b/src/app/api/graphql/route.tsx
@@ -1,14 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers'; // Import for cookie handling
 
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
+
+    const accessToken = cookies().get('accessToken')?.value;
 
     const response = await fetch(process.env.API_URL as string, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'X-Api-Key': process.env.API_KEY as string,
+        'Authorization': accessToken as string,
       },
       body: JSON.stringify(body),
     });
@@ -18,7 +22,19 @@ export async function POST(request: NextRequest) {
     }
 
     const data = await response.json();
-    return NextResponse.json(data);
+    const nextResponse = NextResponse.json(data);
+
+    const authHeader = response.headers.get("authorization");
+    if (authHeader) {
+      // Set the access token as an HTTP-only cookie
+      cookies().set('accessToken', authHeader, {
+        httpOnly: true,
+        maxAge: 24 * 60 * 60, // Cookie expiration time
+        sameSite: 'strict',
+      });
+    }
+
+    return nextResponse;
   } catch (error) {
     console.error('Error in GraphQL proxy:', error);
     return NextResponse.json(


### PR DESCRIPTION
There are three layers

1. The client side of the React Next.js application
2. The server side of the React Next.js application
3. The backend GQL server.

The client side of the React Next.js application is javascript code that runs in a browser.
The client sends an http request to the Next.js server side.
The Next.js server side forwards the http request to the backend GQL server.

When a user logs in successfully, the backend server includes a JWT token in the authorization response header.
The Next.js server accesses this header and put the JWT token into a response cookie.

The browser client includes this cookie with subsequent requests.
For each subsequent request, the Next.js server will access the JWT token.
And forward it to the backend GQL server in the authorization request header. 